### PR TITLE
Rewrite the readme opening block to lead with the differentiator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,22 @@
 # Create PubSub
 
-A tiny Event Emitter and Observable Store for JavaScript apps.
+A tiny Event Emitter and Observable Store for JavaScript apps. You destructure a pair of named functions instead of passing event-name strings around, so there are no event names to keep in sync and your editor completes them for you.
 
-Supported environments: [Browser](https://gs.statcounter.com/browser-market-share), [Node](https://nodejs.org/) and [Deno](https://deno.land/).
+- **Tiny.** The ES Module build is 207 bytes (175 gzipped), with zero dependencies.
+- **No string event names.** `const [gameStarted, onGameStarted] = createPubSub()`, and you pick both names.
+- **Emitter or store.** Pass an initial value and you also get a getter, plus the previous value on every update.
+- **Runs everywhere.** Browser, [Node](https://nodejs.org/) and [Deno](https://deno.com/), as an ES Module, a CommonJS module or a plain script tag.
+- **Optional extras.** A [`usePubSub` React hook](#example-react-hook) and an [Immer-backed variant](#example-working-with-immutable-data), in separate entry points.
 
-This is a Vanilla JavaScript library, so it's framework-agnostic. But if you're using [React](https://reactjs.org/), check out the built-in support for it in the examples. And if you're planning to store immutable data, check also the built-in support for [Immer](https://immerjs.github.io/immer/).
+```ts
+const [pub, sub] = createPubSub<string>();
+
+sub((data) => console.log(`Hello ${data}!`));
+
+pub("World"); // Prints "Hello World!".
+```
+
+It's written in vanilla JavaScript, so it's framework-agnostic.
 
 ## Install
 
@@ -58,16 +70,6 @@ const [pub, sub, get] = createPubSub(initialValue);
 ```
 
 ## Examples
-
-### Example: Getting Started
-
-```ts
-const [pub, sub] = createPubSub<string>();
-
-sub((data) => console.log(`Hello ${data}!`));
-
-pub("World"); // Prints "Hello World!".
-```
 
 ### Example: Naming Functions
 


### PR DESCRIPTION
Reorders the top of the readme so the first screen carries the reasons to keep reading, following the [good-readme skill](https://github.com/evilmartians/agent-skills/blob/main/skills/good-readme/SKILL.md) from Evil Martians (companion to [How to make your open source popular](https://evilmartians.com/chronicles/how-to-make-your-open-source-popular)).

This PR does four things:

- The opening paragraph now states the actual differentiator: you destructure a pair of named functions instead of passing event-name strings around. That was buried in "Example: Naming Functions", halfway down the page.
- Adds a list of facts with measured numbers right below it: size, zero dependencies, emitter-or-store, supported environments, and the React and Immer entry points.
- Moves "Example: Getting Started" up into the opening block, unchanged, so a working example lands before `Install`.
- Replaces the "Supported environments" line, whose "Browser" pointed at StatCounter's browser market share, and updates the Deno link to `deno.com`.

The size claim is measured, not estimated: `main/index.mjs` is 207 bytes (175 gzipped), both in the published `create-pubsub@1.6.3` tarball from npm and in a fresh local build. `src` hasn't changed since `v1.6.3`, so the two agree.

## How to test

1. Open the readme preview and check that the first screen answers what it does, how it helps, and how it differs.
2. Click the two anchor links in the "Optional extras" bullet; they should jump to the React Hook and the Immer examples.
3. Run `npm test` (14 tests, unaffected by this change, but the immer example in the readme is covered by one of them).

Note: the readme on npmjs.com only picks this up on the next release.
