### PR TITLE
Declare react and immer as optional peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,18 @@
         "tslib": "2.8.1",
         "typescript": "^7.0.2",
         "watchlist": "0.3.1"
+      },
+      "peerDependencies": {
+        "immer": ">=9",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -81,5 +81,17 @@
     "tslib": "2.8.1",
     "typescript": "^7.0.2",
     "watchlist": "0.3.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "immer": ">=9"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "immer": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
- Fixes https://github.com/felladrin/create-pubsub/issues/928

## Root cause

create-pubsub/react needs react at runtime, and create-pubsub/immer needs immer, but package.json did not declare any peerDependencies (both were only devDependencies).

## What changed

- Add react >=16.8 and immer >=9 as peerDependencies
- Mark both as optional via peerDependenciesMeta so users who only use the main entry point get no warnings

Note: .npmrc with legacy-peer-deps is still required due to a global-jsdom / jsdom peer conflict (global-jsdom@29 expects jsdom <30, but we use jsdom@30).

## Verification

- All 14 tests pass
- `npm install` works without warnings for the optional peers