### PR TITLE
Switch npm publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 name: Publish Package
 on:
  release:
-   types: [created]
+   types: [published]
 jobs:
  build:
    runs-on: ubuntu-latest
@@ -18,5 +18,3 @@ jobs:
      - run: npm install -g npm
      - run: npm ci
      - run: npm publish --provenance --access public
-       env:
-         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Fixes https://github.com/felladrin/create-pubsub/issues/932

## Root cause

The publish workflow authenticates with a long-lived token (`secrets.NPM_TOKEN`). npm revoked classic tokens at the end of 2025, and granular tokens expire now.

## What changed

- Remove `NODE_AUTH_TOKEN` env var from the workflow
- Keep `id-token: write` (already present) for OIDC authentication
- `--provenance` keeps working as before

**Important:** Before merging, the trusted publisher must be configured on npmjs.com (package settings > Trusted publishers > add this repo and the `npm-publish.yml` workflow).

## Verification

- Workflow YAML is valid
- `id-token: write` permission already in place
- npm CLI 11.5.1+ required (workflow already runs `npm install -g npm`)