### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security updates.
+
+## Reporting a Vulnerability
+
+Please [report a vulnerability](https://github.com/felladrin/create-pubsub/security/advisories/new) through GitHub's private vulnerability reporting.


### PR DESCRIPTION
## What changed

Add a minimal SECURITY.md so there's a documented way to report
vulnerabilities privately via GitHub's Security tab.

Only the latest release is supported with security updates.

## Verification

- File follows GitHub's SECURITY.md conventions
- Links to the repo's security advisories page

Fixes #935